### PR TITLE
add "--flip-vertical" argument to flip Y axis so sequences appear below reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,139 @@
+# from https://github.com/github/gitignore/blob/master/Python.gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ optional arguments:
   --width WIDTH         Overwrite the default figure width
   --size-option SIZE_OPTION
                         Specify options for sizing. Options: expand, scale
+  --flip-vertical       Flip the orientation of the plot so sequences are below the reference rather than above it
   -c COLOUR_PALETTE, --colour-palette COLOUR_PALETTE
                         Specify colour palette. Options: primary, classic, purine-pyrimidine, greyscale, wes, verity
 ```

--- a/snipit/command.py
+++ b/snipit/command.py
@@ -36,6 +36,8 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument("--height",action="store",type=float,help="Overwrite the default figure height",default=0)
     parser.add_argument("--width",action="store",type=float,help="Overwrite the default figure width",default=0)
     parser.add_argument("--size-option",action="store",help="Specify options for sizing. Options: expand, scale",dest="size_option",default="scale")
+    
+    parser.add_argument("--flip-vertical",action='store_true',help="Flip the orientation of the plot so sequences are below the reference rather than above it.",dest="flip_vertical")
 
     parser.add_argument("-c","--colour-palette",dest="colour_palette",action="store",help="Specify colour palette. Options: primary, classic, purine-pyrimidine, greyscale, wes, verity",default="classic")
 
@@ -74,7 +76,7 @@ def main(sysargs = sys.argv[1:]):
     sfunks.check_format(args.format)
     sfunks.check_size_option(args.size_option)
 
-    sfunks.make_graph(num_seqs,num_snps,record_ambs,record_snps,output,label_map,colours,length,args.width,args.height,args.size_option)
+    sfunks.make_graph(num_seqs,num_snps,record_ambs,record_snps,output,label_map,colours,length,args.width,args.height,args.size_option,args.flip_vertical)
 
 if __name__ == '__main__':
     main()

--- a/snipit/command.py
+++ b/snipit/command.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
-from snipit import __version__
-import argparse
-import os
-import pkg_resources
-from . import _program
-from Bio import SeqIO
-import collections
-import snp_functions as sfunks
+
+# imports of built-ins
 import sys
+import os
+import argparse
+import pkg_resources
+import collections
+
+# imports from other modules
+from Bio import SeqIO
+
+# imports from this module
+from snipit import __version__
+from . import _program
 
 thisdir = os.path.abspath(os.path.dirname(__file__))
 cwd = os.getcwd()

--- a/snipit/scripts/snp_functions.py
+++ b/snipit/scripts/snp_functions.py
@@ -200,6 +200,7 @@ def find_ambiguities(alignment, snp_dict):
 
 def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_dict,length,width,height,size_option):
     
+def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_dict,length,width,height,size_option,flip_vertical=False):
     y_level = 0
     ref_vars = {}
     snp_dict = collections.defaultdict(list)

--- a/snipit/scripts/snp_functions.py
+++ b/snipit/scripts/snp_functions.py
@@ -198,8 +198,6 @@ def find_ambiguities(alignment, snp_dict):
 
     return amb_dict
 
-def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_dict,length,width,height,size_option):
-    
 def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_dict,length,width,height,size_option,flip_vertical=False):
     y_level = 0
     ref_vars = {}
@@ -269,7 +267,7 @@ def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_di
     # width and height of the figure
     fig, ax = plt.subplots(1,1, figsize=(width,height), dpi=250)
 
-    y_level =0
+    y_level = 0
 
     for record in snp_records:
 
@@ -284,12 +282,16 @@ def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_di
         ax.add_patch(rect)
 
         # for each record add the name to the left hand side
-        ax.text(-20, y_level, label_map[record], size=9, ha="right", va="center")
+        ax.text(-50, y_level, label_map[record], size=9, ha="right", va="center")
 
     position = 0
     for snp in sorted(snp_dict):
         position += spacing
-        ax.text(position, y_level+(0.5*y_inc), snp, size=9, ha="center", va="bottom", rotation=90)
+        
+        # write text adjacent to the SNPs shown with the numeric position
+        # the text alignment is toggled right/left (top/bottom considering 90-deg rotation) if the plot is flipped
+        ax.text(position, y_level+(0.55*y_inc), snp, size=9, ha="center", va="bottom" if not flip_vertical else "top", rotation=90)
+
         # snp position labels
         left_of_box = position-(0.4*spacing)
         right_of_box = position+(0.4*spacing)
@@ -302,7 +304,6 @@ def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_di
             name,ref,var,y_pos = sequence
             bottom_of_box = (y_pos*y_inc)-(0.5*y_inc)
             
-
             # draw box for snp
             if var in colour_dict:
                 rect = patches.Rectangle((left_of_box,bottom_of_box),spacing*0.8,  y_inc,alpha=0.5, fill=True, edgecolor='none',facecolor=colour_dict[var.upper()])
@@ -356,7 +357,12 @@ def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_di
     plt.yticks([])
             
     ax.set_xlim(0,length)
-    ax.set_ylim(ref_genome_position,y_level+(y_inc*1.05))
+    if not flip_vertical:
+        ax.set_ylim(ref_genome_position,y_level+(y_inc*1.05))
+    else:
+        ax.set_ylim(ref_genome_position,y_level+(y_inc*2.05))
+        ax.invert_yaxis() # must be called after axis limits are set
+
     ax.tick_params(axis='x', labelsize=8)
     plt.xlabel("Genome position (base)", fontsize=9)
     plt.tight_layout()

--- a/snipit/scripts/snp_functions.py
+++ b/snipit/scripts/snp_functions.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
+
+# imports of built-ins
 import os
+import sys
 import argparse
+import collections
+from itertools import cycle
+import csv
+import math
+
+# imports from other modules
+from Bio import SeqIO
 import matplotlib as mpl
 from matplotlib import pyplot as plt
-import csv
-import collections
 import matplotlib.patches as patches
 from matplotlib.patches import Polygon
-from itertools import cycle
-import math
-import sys
-from Bio import SeqIO
 
 colour_list = ["lightgrey","white"]
 colour_cycle = cycle(colour_list)


### PR DESCRIPTION
Thanks so much for making `snipit`, @aineniamh. I learned about it as a result of your excellent ASM NGS conference talk today. The plots it makes are beautiful.

I'm not sure how welcome contributions may be, or if there are contribution/style guidelines I should be following, but I made a small prospective addition:

This PR introduces a new argument, `--flip-vertical`, which, if specified, inverts the y-axis so sequence patches and text are drawn below the reference sequence rather than above (for those who prefer such a view—could be better for print). It does this by calling `ax.invert_yaxis()` after the y-axis limits have been set if `--flip-vertical` is specified. This way all drawing can be done as usual with no change to the coordinate space, though some tweaks to aligned elements may be necessary in places; for example, when the plot is flipped vertically the text alignment of the numeric position labels is toggled so they align to suit with the new orientation. This PR also includes a `.gitignore` file so `*.pyc` etc. files are ignored from commits, and a few small changes that are evident from the diffs.

Unrelated to this PR, but I also made a [bioconda recipe](https://github.com/bioconda/bioconda-recipes/pull/25759) for snipit since I saw it was released under an open license—I hope that's ok! This tool meets a need we've had for a while for various projects, so I'm glad it exists and works so well.
