### PR TITLE
change '--ignore-positions' to include/exclude ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Summarise snps relative to a reference sequence
 
 ### Usage
 ```
+usage: snipit <alignment> [options]
+
 snipit
 
 positional arguments:
@@ -18,8 +20,7 @@ optional arguments:
   -l LABELS, --labels LABELS
                         Optional csv file of labels to show in output snipit plot. Default: sequence names
   --l-header LABEL_HEADERS
-                        Comma separated string of column headers in label csv. First field indicates sequence name column, second the label column.
-                        Default: 'name,label'
+                        Comma separated string of column headers in label csv. First field indicates sequence name column, second the label column. Default: 'name,label'
   -d OUTPUT_DIR, --output-dir OUTPUT_DIR
                         Output directory. Default: current working directory
   -o OUTFILE, --output-file OUTFILE
@@ -30,7 +31,14 @@ optional arguments:
   --width WIDTH         Overwrite the default figure width
   --size-option SIZE_OPTION
                         Specify options for sizing. Options: expand, scale
-  --flip-vertical       Flip the orientation of the plot so sequences are below the reference rather than above it
+  --flip-vertical       Flip the orientation of the plot so sequences are below the reference rather than above it.
+  --include-positions INCLUDED_POSITIONS [INCLUDED_POSITIONS ...]
+                        One or more range (closed, inclusive; one-indexed) or specific position only included in the output. Ex. '100-150' or Ex. '100 101' Considered
+                        before '--exclude-positions'.
+  --exclude-positions IGNORED_POSITIONS [IGNORED_POSITIONS ...]
+                        One or more range (closed, inclusive; one-indexed) or specific position to exclude in the output. Ex. '100-150' or Ex. '100 101' Considered after '
+                        --include-positions'.
+  --exclude-ambig-pos   Exclude positions with ambig base in any sequences. Considered after '--include-positions'
   -c COLOUR_PALETTE, --colour-palette COLOUR_PALETTE
                         Specify colour palette. Options: primary, classic, purine-pyrimidine, greyscale, wes, verity
 ```


### PR DESCRIPTION
This replaces the argument `--ignore-positions`, which was confusingly named and only accepted specific integer positions, with `--exclude-positions` which accepts numeric ranges or specific positions (ex. '100-200' or '100 105'). A related argument, `--include-positions`, is provided to allow the user to pass a restricted range or list of positions to be included (only), as suggested by @aineniamh in [#2](https://github.com/aineniamh/snipit/pull/2#issuecomment-752918562). Position exclusion is considered after position inclusion. This also moves the x-axis scale labels to be adjacent to the genome map if `--flip-vertical` is specified.