### PR TITLE
Option to sort sequences in output graphic by SNP count

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ optional arguments:
   --exclude-ambig-pos   Exclude positions with ambig base in any sequences. Considered after '--include-positions'
   --sort-by-mutation-number
                         Render the graph with sequences sorted by the number of SNPs relative to the reference (fewest to most). Default: False
-  --high-to-low         If sorted by mutation number is selected, show the sequences with the most SNPs starting at the top. Default: False
+  --high-to-low         If sorted by mutation number is selected, show the sequences with the fewest SNPs closest to the reference. Default: False
   -c COLOUR_PALETTE, --colour-palette COLOUR_PALETTE
                         Specify colour palette. Options: primary, classic, purine-pyrimidine, greyscale, wes, verity
 ```

--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ optional arguments:
                         Specify options for sizing. Options: expand, scale
   --flip-vertical       Flip the orientation of the plot so sequences are below the reference rather than above it.
   --include-positions INCLUDED_POSITIONS [INCLUDED_POSITIONS ...]
-                        One or more range (closed, inclusive; one-indexed) or specific position only included in the output. Ex. '100-150' or Ex. '100 101' Considered
-                        before '--exclude-positions'.
-  --exclude-positions IGNORED_POSITIONS [IGNORED_POSITIONS ...]
-                        One or more range (closed, inclusive; one-indexed) or specific position to exclude in the output. Ex. '100-150' or Ex. '100 101' Considered after '
-                        --include-positions'.
+                        One or more range (closed, inclusive; one-indexed) or specific position only included in the output. Ex. '100-150' or Ex. '100 101' Considered before '--exclude-positions'.
+  --exclude-positions EXCLUDED_POSITIONS [EXCLUDED_POSITIONS ...]
+                        One or more range (closed, inclusive; one-indexed) or specific position to exclude in the output. Ex. '100-150' or Ex. '100 101' Considered after '--include-positions'.
   --exclude-ambig-pos   Exclude positions with ambig base in any sequences. Considered after '--include-positions'
+  --sort-by-mutation-number
+                        Render the graph with sequences sorted by the number of SNPs relative to the reference (fewest to most). Default: False
+  --high-to-low         If sorted by mutation number is selected, show the sequences with the most SNPs starting at the top. Default: False
   -c COLOUR_PALETTE, --colour-palette COLOUR_PALETTE
                         Specify colour palette. Options: primary, classic, purine-pyrimidine, greyscale, wes, verity
 ```

--- a/snipit/command.py
+++ b/snipit/command.py
@@ -66,7 +66,7 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument("--sort-by-mutation-number", action='store_true',
                         help="Render the graph with sequences sorted by the number of SNPs relative to the reference (fewest to most). Default: False", dest="sort_by_mutation_number")
     parser.add_argument("--high-to-low", action='store_false',
-                        help="If sorted by mutation number is selected, show the sequences with the most SNPs starting at the top. Default: False",
+                        help="If sorted by mutation number is selected, show the sequences with the fewest SNPs closest to the reference. Default: False",
                         dest="high_to_low")
 
     parser.add_argument("-c","--colour-palette",dest="colour_palette",action="store",help="Specify colour palette. Options: primary, classic, purine-pyrimidine, greyscale, wes, verity",default="classic")

--- a/snipit/command.py
+++ b/snipit/command.py
@@ -63,7 +63,11 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument('--include-positions', dest='included_positions', type=bp_range, nargs='+', default=None, help="One or more range (closed, inclusive; one-indexed) or specific position only included in the output. Ex. '100-150' or Ex. '100 101' Considered before '--exclude-positions'.")
     parser.add_argument('--exclude-positions', dest='excluded_positions', type=bp_range, nargs='+', default=None, help="One or more range (closed, inclusive; one-indexed) or specific position to exclude in the output. Ex. '100-150' or Ex. '100 101' Considered after '--include-positions'.")
     parser.add_argument("--exclude-ambig-pos",dest="exclude_ambig_pos",action='store_true',help="Exclude positions with ambig base in any sequences. Considered after '--include-positions'")
-
+    parser.add_argument("--sort-by-mutation-number", action='store_true',
+                        help="Render the graph with sequences sorted by the number of SNPs relative to the reference (fewest to most). Default: False", dest="sort_by_mutation_number")
+    parser.add_argument("--high-to-low", action='store_false',
+                        help="If sorted by mutation number is selected, show the sequences with the most SNPs starting at the top. Default: False",
+                        dest="high_to_low")
 
     parser.add_argument("-c","--colour-palette",dest="colour_palette",action="store",help="Specify colour palette. Options: primary, classic, purine-pyrimidine, greyscale, wes, verity",default="classic")
 
@@ -102,9 +106,9 @@ def main(sysargs = sys.argv[1:]):
     sfunks.check_format(args.format)
     sfunks.check_size_option(args.size_option)
 
-    sfunks.make_graph(num_seqs,num_snps,record_ambs,record_snps,output,label_map,colours,length,args.width,args.height,args.size_option,args.flip_vertical,args.included_positions,args.excluded_positions,args.exclude_ambig_pos)
+    sfunks.make_graph(num_seqs,num_snps,record_ambs,record_snps,output,label_map,colours,length,args.width,args.height,args.size_option,args.flip_vertical,args.included_positions,args.excluded_positions,args.exclude_ambig_pos,
+                      args.sort_by_mutation_number,args.high_to_low)
+
 
 if __name__ == '__main__':
     main()
-
-    

--- a/snipit/scripts/snp_functions.py
+++ b/snipit/scripts/snp_functions.py
@@ -8,6 +8,7 @@ import collections
 from itertools import cycle, chain
 import csv
 import math
+from collections import OrderedDict
 
 # imports from other modules
 from Bio import SeqIO
@@ -198,14 +199,26 @@ def find_ambiguities(alignment, snp_dict):
 
     return amb_dict
 
-def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_dict,length,width,height,size_option,flip_vertical=False,included_positions=None,excluded_positions=None,exclude_ambig_pos=False):
+def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_dict,length,width,height,size_option,
+               flip_vertical=False,included_positions=None,excluded_positions=None,exclude_ambig_pos=False,
+               sort_by_mutation_number=False,high_to_low=True):
     y_level = 0
     ref_vars = {}
     snp_dict = collections.defaultdict(list)
     included_positions = set(chain.from_iterable(included_positions)) if included_positions is not None else set()
-    excluded_positions  = set(chain.from_iterable(excluded_positions)) if excluded_positions is not None else set()
+    excluded_positions = set(chain.from_iterable(excluded_positions)) if excluded_positions is not None else set()
 
-    for record in snp_records:
+    if sort_by_mutation_number:
+        snp_counts = {}
+        for record in snp_records:
+            snp_counts[record] = int(len(snp_records[record]))
+        ordered_dict = dict(sorted(snp_counts.items(), key=lambda item: item[1], reverse=high_to_low))
+        record_order = list(OrderedDict(ordered_dict).keys())
+
+    else:
+        record_order = list(snp_records.keys())
+
+    for record in record_order:
 
         # y level increments per record
         y_level +=1
@@ -295,7 +308,7 @@ def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_di
 
     y_level = 0
 
-    for record in snp_records:
+    for record in record_order:
 
         # y position increments
         y_level += y_inc


### PR DESCRIPTION
By default, snipit shows the sequences in the graphic by the order in which they appear in the alignment file. This PR adds the option to show the order of sequences by their relative number of SNPs to the reference. The idea here is to be able to loosely group and arrange sequences with similar SNP counts together without needing to know much about the sequences beforehand, potentially bringing identical or very similar sequences closer together for easier visual comparison. This option is disabled by default. 

By default, the sequences with the highest SNPs will be shown next to the reference. The intuition is to have the sequences that need the most visual comparison (most number of SNPs) closest to the reference to aid the visual assessment. This can be changed by enabling the --high-to-low option, which puts the sequences(s) with the fewest SNPs next to the reference. 