### PR TITLE
Add options to sort by sequence name and mutations at provided positions

### DIFF
--- a/snipit/command.py
+++ b/snipit/command.py
@@ -67,6 +67,7 @@ def main(sysargs = sys.argv[1:]):
                         help="Render the graph with sequences sorted by the number of SNPs relative to the reference (fewest to most). Default: False", dest="sort_by_mutation_number")
     parser.add_argument("--sort-by-id", action='store_true',
                         help="Sort sequences alphabetically by sequence id. Default: False", dest="sort_by_id")
+    parser.add_argument("--sort-by-mutations", type=str, help="Sort sequences by bases at specified positions. Positions are comma separated integers. Ex. '1,2,3'", dest="sort_by_mutations")
     parser.add_argument("--high-to-low", action='store_false',
                         help="If sorted by mutation number is selected, show the sequences with the fewest SNPs closest to the reference. Default: False",
                         dest="high_to_low")
@@ -109,7 +110,7 @@ def main(sysargs = sys.argv[1:]):
     sfunks.check_size_option(args.size_option)
 
     sfunks.make_graph(num_seqs,num_snps,record_ambs,record_snps,output,label_map,colours,length,args.width,args.height,args.size_option,args.flip_vertical,args.included_positions,args.excluded_positions,args.exclude_ambig_pos,
-                      args.sort_by_mutation_number,args.high_to_low,args.sort_by_id)
+                      args.sort_by_mutation_number,args.high_to_low,args.sort_by_id,args.sort_by_mutations)
 
 
 if __name__ == '__main__':

--- a/snipit/command.py
+++ b/snipit/command.py
@@ -65,6 +65,8 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument("--exclude-ambig-pos",dest="exclude_ambig_pos",action='store_true',help="Exclude positions with ambig base in any sequences. Considered after '--include-positions'")
     parser.add_argument("--sort-by-mutation-number", action='store_true',
                         help="Render the graph with sequences sorted by the number of SNPs relative to the reference (fewest to most). Default: False", dest="sort_by_mutation_number")
+    parser.add_argument("--sort-by-id", action='store_true',
+                        help="Sort sequences alphabetically by sequence id. Default: False", dest="sort_by_id")
     parser.add_argument("--high-to-low", action='store_false',
                         help="If sorted by mutation number is selected, show the sequences with the fewest SNPs closest to the reference. Default: False",
                         dest="high_to_low")
@@ -107,7 +109,7 @@ def main(sysargs = sys.argv[1:]):
     sfunks.check_size_option(args.size_option)
 
     sfunks.make_graph(num_seqs,num_snps,record_ambs,record_snps,output,label_map,colours,length,args.width,args.height,args.size_option,args.flip_vertical,args.included_positions,args.excluded_positions,args.exclude_ambig_pos,
-                      args.sort_by_mutation_number,args.high_to_low)
+                      args.sort_by_mutation_number,args.high_to_low,args.sort_by_id)
 
 
 if __name__ == '__main__':

--- a/snipit/scripts/snp_functions.py
+++ b/snipit/scripts/snp_functions.py
@@ -201,7 +201,7 @@ def find_ambiguities(alignment, snp_dict):
 
 def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_dict,length,width,height,size_option,
                flip_vertical=False,included_positions=None,excluded_positions=None,exclude_ambig_pos=False,
-               sort_by_mutation_number=False,high_to_low=True):
+               sort_by_mutation_number=False,high_to_low=True,sort_by_id=False):
     y_level = 0
     ref_vars = {}
     snp_dict = collections.defaultdict(list)
@@ -214,7 +214,10 @@ def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_di
             snp_counts[record] = int(len(snp_records[record]))
         ordered_dict = dict(sorted(snp_counts.items(), key=lambda item: item[1], reverse=high_to_low))
         record_order = list(OrderedDict(ordered_dict).keys())
-
+    
+    elif sort_by_id:
+        record_order = list(sorted(snp_records.keys())) 
+    
     else:
         record_order = list(snp_records.keys())
 

--- a/snipit/scripts/snp_functions.py
+++ b/snipit/scripts/snp_functions.py
@@ -201,7 +201,7 @@ def find_ambiguities(alignment, snp_dict):
 
 def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_dict,length,width,height,size_option,
                flip_vertical=False,included_positions=None,excluded_positions=None,exclude_ambig_pos=False,
-               sort_by_mutation_number=False,high_to_low=True,sort_by_id=False):
+               sort_by_mutation_number=False,high_to_low=True,sort_by_id=False,sort_by_mutations=False):
     y_level = 0
     ref_vars = {}
     snp_dict = collections.defaultdict(list)
@@ -217,6 +217,23 @@ def make_graph(num_seqs,num_snps,amb_dict,snp_records,output,label_map,colour_di
     
     elif sort_by_id:
         record_order = list(sorted(snp_records.keys())) 
+
+    elif sort_by_mutations:
+        mutations = sort_by_mutations.split(",")
+        sortable_record = {}
+        for record in snp_records:
+            bases = []
+            for sort_mutation in mutations:
+                found = False
+                for record_mutation in snp_records[record]:
+                    if int(record_mutation[:-2]) == int(sort_mutation):
+                        bases.append(record_mutation[-1])
+                        found = True
+                        break
+                if not found:
+                    bases.append("0")
+            sortable_record[record] = "".join(bases) + record
+        record_order = list(OrderedDict(sorted(sortable_record.items(), key=lambda item: item[1], reverse=high_to_low)).keys())
     
     else:
         record_order = list(snp_records.keys())


### PR DESCRIPTION
- feat: sort by sequence name/id
- feat: add option to sort by mutations

### Usage

`snipit alignment.fasta --sort-by-id` to sort by sequence name

`snipit alignment.fasta --sort-by-mutations 27788,27384,21570,23535,8303,1627,1931,16935` to sort by bases at position 27788, then break ties by nuc at mutation 27384, 21570 etc.